### PR TITLE
Fix typo and add warning in documentation

### DIFF
--- a/fastcluster.h
+++ b/fastcluster.h
@@ -67,7 +67,7 @@ enum hclust_fast_methods {
   HCLUST_METHOD_SINGLE = 0,
   // complete link with the nearest-neighbor-chain algorithm (Murtagh, 1984)
   HCLUST_METHOD_COMPLETE = 1,
-  // omplete link with the nearest-neighbor-chain algorithm (Murtagh, 1984)
+  // unweighted average link with the nearest-neighbor-chain algorithm (Murtagh, 1984)
   HCLUST_METHOD_AVERAGE = 2,
   // median link with the generic algorithm (Müllner, 2011)
   HCLUST_METHOD_MEDIAN = 3

--- a/fastcluster.h
+++ b/fastcluster.h
@@ -70,6 +70,7 @@ enum hclust_fast_methods {
   // unweighted average link with the nearest-neighbor-chain algorithm (Murtagh, 1984)
   HCLUST_METHOD_AVERAGE = 2,
   // median link with the generic algorithm (Müllner, 2011)
+  // requires euclidean distances as distance data
   HCLUST_METHOD_MEDIAN = 3
 };
   


### PR DESCRIPTION
Thanks very much for this project, it has been very helpful for our work.

These are just simple documentation changes: a fixed typo, and a warning to those (like me) who are new to clustering, that the median method works with Euclidean distances.